### PR TITLE
ci(auto-merge): match Dependabot's automerge-minor label

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -22,7 +22,8 @@ jobs:
         uses: pascalgn/automerge-action@v0.16.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MERGE_LABELS: automerge
+          # Dependabot labels its minor/patch PRs "automerge-minor" (majors are ignored)
+          MERGE_LABELS: automerge-minor
           MERGE_METHOD: squash
           MERGE_COMMIT_MESSAGE: pull-request-title-and-description
           MERGE_REQUIRED_APPROVALS: "1"


### PR DESCRIPTION
## What
Changes the auto-merge workflow's `MERGE_LABELS` from `automerge` → **`automerge-minor`**.

## Why
Dependabot labels its PRs **`automerge-minor`** (and is configured to ignore major bumps), but the workflow only auto-merged PRs labeled `automerge`. Result: **10 queued minor/patch Dependabot PRs could never auto-merge**.

Matching the label lets them merge automatically once they're **green + have 1 approval** (the 1-approval safety gate is retained — drop `MERGE_REQUIRED_APPROVALS` to `0` later if you want fully hands-off minor merges).

## Note
The existing Dependabot PRs predate the npmjs.org lockfile fix (#73), so they may need a **rebase** to pick it up before their CI goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
