### PR TITLE
fix(husky): migrate git hooks to husky v9 so commits are gated

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,2 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
+#!/usr/bin/env sh
 npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,2 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
+#!/usr/bin/env sh
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "preinstall": "node check-npm.js",
     "postinstall": "node scripts/copy-alphatab-assets.js",
+    "prepare": "husky",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
## Summary

`lint-staged` and `commitlint` now actually run on every commit. They were **silently skipped on every commit** — so unformatted code and non-conventional commit messages could land with nothing stopping them (this was discovered during the PWA PR #81, where every commit had to be verified by hand).

Two independent root causes, both fixed here:

1. **Non-executable hooks.** `.husky/pre-commit` and `.husky/commit-msg` were tracked as mode `100644`, so git ignored them (`hook was ignored because it's not set as executable`).
2. **Deprecated v8 format with no shim.** Both hooks sourced `. "$(dirname "$0")/_/husky.sh"`, but `.husky/_/husky.sh` was never generated — there was no `"prepare": "husky"` script to run husky's init. Even when made executable, the hooks errored on the missing `husky.sh`.

## What changed

- **Drop the `_/husky.sh` sourcing line** from both hooks — husky v9 hooks are plain scripts (the generated `.husky/_/` wrappers handle the shim). v9 deprecates that sourcing line.
- **Mark both hooks executable** (`100644 → 100755`).
- **Add `"prepare": "husky"`** so `npm`/`yarn install` regenerates `.husky/_` and sets a **relative** `core.hooksPath` (`.husky/_`).

That last point is also the **git-worktree fix**: `core.hooksPath` was an *absolute* path to the main checkout's `.husky`, so every linked worktree ran the *main* checkout's hooks instead of its own. The relative path husky configures resolves per-worktree.

## Verification

Hooks confirmed firing (no `husky.sh` error) under both layouts:

- **Wrapper model** (`core.hooksPath=.husky/_`, the post-install default): a real commit ran `lint-staged` (prettier) + `commitlint`. `commitlint` even **correctly rejected** a commit whose body exceeded 100 chars (`body-max-line-length`) — proving it now gates messages.
- **Direct model** (absolute `core.hooksPath`, the path existing worktree overrides use against main's hooks): an empty commit fired `lint-staged` + `commitlint` and passed — the shebang + exec bit keep this path working too.

`.husky/_/` stays gitignored (husky writes `.husky/_/.gitignore` containing `*`), so only the two hook files and the `prepare` script are committed.

## One-time migration for existing local checkouts

After pulling this, run **`yarn install` once** — husky's `prepare` regenerates `.husky/_` and sets the relative `core.hooksPath`. A worktree that still has a stale *absolute* `core.hooksPath` in its per-worktree config (this repo has `extensions.worktreeConfig=true`) can clear it with:

```sh
git config --worktree --unset core.hooksPath   # falls back to the shared .husky/_
```

Fresh clones and CI need nothing extra.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
