### PR TITLE
fix(player): stop loading overlay sticking at 30% on file load

### DIFF
--- a/src/lib/alphatab-utils.ts
+++ b/src/lib/alphatab-utils.ts
@@ -199,27 +199,41 @@ export const useAlphaTabEvent = (
   event: string,
   handler: (...args: unknown[]) => void,
 ) => {
+  // Keep the latest handler in a ref so the subscription stays stable across
+  // renders. Handlers are defined inline at call sites, so their identity
+  // changes every render; depending on `handler` here would off()/on() the
+  // event on every render. AlphaTab's `scoreLoaded` emitter *replays* its
+  // current value to each new subscriber (fireOnRegister), so re-subscribing
+  // every render re-fired `scoreLoaded` repeatedly — which left the loading
+  // overlay stuck at 30% ("Processing score...") because the last replay reset
+  // isLoading=true after rendering had already finished. Subscribe once per
+  // (api, event) instead and always invoke the current handler via the ref.
+  const handlerRef = React.useRef(handler);
   React.useEffect(() => {
-    if (api) {
-      try {
-        // Use the proper AlphaTab event system with .on() method
-        const eventEmitter = api[event as keyof alphaTab.AlphaTabApi] as
-          | Partial<IEventEmitter>
-          | Partial<IEventEmitterOfT<unknown>>
-          | undefined;
-        if (eventEmitter && typeof eventEmitter.on === 'function') {
-          eventEmitter.on(handler);
-          return () => {
-            if (typeof eventEmitter.off === 'function') {
-              eventEmitter.off(handler);
-            }
-          };
-        } else {
-          console.warn(`Event ${event} not available or not properly initialized`);
-        }
-      } catch (error) {
-        console.error(`Failed to attach event handler for ${event}:`, error);
+    handlerRef.current = handler;
+  });
+
+  React.useEffect(() => {
+    if (!api) return;
+    try {
+      // Use the proper AlphaTab event system with .on() method
+      const eventEmitter = api[event as keyof alphaTab.AlphaTabApi] as
+        | Partial<IEventEmitter>
+        | Partial<IEventEmitterOfT<unknown>>
+        | undefined;
+      if (eventEmitter && typeof eventEmitter.on === 'function') {
+        const stableHandler = (...args: unknown[]) => handlerRef.current(...args);
+        eventEmitter.on(stableHandler);
+        return () => {
+          if (typeof eventEmitter.off === 'function') {
+            eventEmitter.off(stableHandler);
+          }
+        };
+      } else {
+        console.warn(`Event ${event} not available or not properly initialized`);
       }
+    } catch (error) {
+      console.error(`Failed to attach event handler for ${event}:`, error);
     }
-  }, [api, event, handler]);
+  }, [api, event]);
 };


### PR DESCRIPTION
## Summary

Follow-up to #87. After the worker fix landed, the loading overlay stayed at **30% ("Processing score…")** on every file load and never cleared — even the 10s fallback didn't hide it.

## Root cause

`useAlphaTabEvent` re-subscribed on **every render**: the event handlers are defined inline at the call sites, so their identity changes each render, and the effect listed `handler` in its dependencies → `off()` + `on()` every render.

AlphaTab's `scoreLoaded` emitter is constructed with a `fireOnRegister` callback, so `.on()` **replays the current score to each new subscriber**:

```js
on(value) {
  this._listeners.push(value);
  if (this._fireOnRegister) { const arg = this._fireOnRegister(); if (arg !== null) value(arg); } // replay
}
```

So every re-render re-ran the `scoreLoaded` handler (`setIsLoading(true)` + `setLoadingProgress(30)`) — including *after* `renderFinished` had already hidden the overlay. The last replay won, leaving it stuck at 30%. (`renderStarted`/`renderFinished` don't replay, so they couldn't counteract it.)

## Fix

Subscribe **once per `(api, event)`** and call the latest handler through a ref, so changing handler identity no longer re-subscribes. `scoreLoaded` now fires once per load; the useful one-shot replay on initial subscribe is preserved.

## Verification

Production build + browser on `/play`, loading a file:
- ✅ `scoreLoaded` fires **1×** (was 6×)
- ✅ overlay clears after render — no "Processing score…" left in the DOM
- ✅ no regressions: 0 console errors, no `file://`, no WebPack warning
- ✅ `build`, `typecheck`, `test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)